### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,7 +55,7 @@ defaultContentLanguageInSubdir = false
 
   # Organizations/Affiliations.
   #   Separate multiple entries with a comma, using the form: `[ {name="Org1", url=""}, {name="Org2", url=""} ]`.
-  organizations = [ { name = "Nothr Carolina State University", url = "https://www.bae.ncsu.edu/" } ]
+  organizations = [ { name = "North Carolina State University", url = "https://www.bae.ncsu.edu/" } ]
 
   gravatar = false  # Get your avatar from Gravatar.com? (true/false)
   avatar = "portrait.jpg"  # Specify an avatar image (in `static/img/` folder) or delete value to disable avatar.


### PR DESCRIPTION
@wenlong-liu, I was working through your blog post on tracking hurricanes when I came across a typo on your homepage. This pull request fixes that. Keep up the great work!

--
Fixing typo of "Nothr Carolina State University" to "North Carolina State University"